### PR TITLE
add-ghas

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -1,0 +1,36 @@
+name: 'Build Test Lint'
+run-name: Build Test Lint of ${{ github.ref_name }} by @${{ github.actor }}
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+  build:
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.14
+    secrets: inherit
+    with:
+      platforms: 'linux/amd64'
+      webTarget: web
+
+  # test:
+  #   needs: build
+  #   uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.14
+  #   with:
+  #     webTarget:
+
+  # lint:
+  #   needs: build
+  #   uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.14
+  #   with:
+  #     webTarget:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,23 @@
+name: "Deploy"
+run-name: Deploy (${{ github.ref_name }} -> ${{ inputs.environment }}) by @${{ github.actor }}
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy to Environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          # - production
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+  deploy:
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.14
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.3
+FROM ruby:3.1.3 as web
 WORKDIR /app
 
 COPY Gemfile* ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,9 @@ volumes:
 services:
 
   web:
-    build: .
+    build:
+      target: web
+      context: .
     volumes:
       - "./:/app/"
       - "./log:/app/log"


### PR DESCRIPTION
adds base build test lint deploy actions so we can use it on branches to fine tune the deploy before committing to main